### PR TITLE
Fixed the issue where a newly added color couldn't be used

### DIFF
--- a/lib/screens/items_overview_screen.dart
+++ b/lib/screens/items_overview_screen.dart
@@ -464,7 +464,7 @@ class _ColorFormState extends State<ColorForm> {
     await db.colorDao.insertValue(
       entity.Color(
         id: null,
-        code: _color.value.toRadixString(16).padLeft(6, '0').substring(2),
+        code: _color.value.toRadixString(16).padLeft(6, '0').substring(2).toUpperCase(),
       ),
     );
 


### PR DESCRIPTION
Fixed the issue #1 where a newly added color  couldn't be used. The error was caused by the fact that the color wasn't converted to uppercase before being stored 